### PR TITLE
Add failing overflow test.

### DIFF
--- a/circuits/lib/query/comparators.circom
+++ b/circuits/lib/query/comparators.circom
@@ -19,7 +19,7 @@ template IN (valueArraySize){
             count += eq[i].out;
         }
 
-        // Greater then
+        // Greater than
         component gt = GreaterThan(252);
         gt.in[0] <== count;
         gt.in[1] <== 0;

--- a/test/query/query.test.ts
+++ b/test/query/query.test.ts
@@ -203,6 +203,19 @@ describe("Test query",  function() {
             await circuit.assertOut(w, expOut);
             await circuit.checkConstraints(w);
         });
+
+        it("#LessThan - p-1 < 10 (false)", async () => {
+            const w = await circuit.calculateWitness({
+                in: "21888242871839275222246405745257275088548364400416034343698204186575808495616",
+                operator: LESS,
+                value: ["10", "0", "0"],
+            }, true);
+
+            const expOut = {out: 0, value: ["10", "0", "0"]}
+
+            await circuit.assertOut(w, expOut);
+            await circuit.checkConstraints(w);
+        });
     });
 
     describe("#GreterThan", function() {


### PR DESCRIPTION
The following test fails by outputting 1 rather than 0. You should expect `218...616 < 10` to be true, but it's not due to an overflow error described [here](https://github.com/BlakeMScurr/comparator-overflow).

I would suggest using `CompConstant` to verify that the inputs are less than `2^252`, but perhaps there's a more efficient way to do that in the context of the codebase.