### PR TITLE
Add binary tag for multiQuery compilation

### DIFF
--- a/circuits/linked/multiQuery.circom
+++ b/circuits/linked/multiQuery.circom
@@ -38,7 +38,7 @@ template LinkedMultiQuery(N, claimLevels, maxValueArraySize) {
     /////////////////////////////////////////////////////////////////
 
     // get safe one values to be used in ForceEqualIfEnabled
-    signal one <== SafeOne()(linkNonce); // 7 constraints
+    signal {binary} one <== SafeOne()(linkNonce); // 7 constraints
 
     // get claim header
     component issuerClaimHeader = getClaimHeader(); // 300 constraints


### PR DESCRIPTION
tags required error when compiling multiQuery.circom with Circom 2.2.1:

error[T3001]: Invalid assignment: missing tags required by input signal.
 Missing tag: input signal enabled requires tag binary
   ┌─ "/…/iden3/circuits/circuits/linked/multiQuery.circom":55:5
   │
55 │     verifyCredentialSchema()(one, issuerClaimHeader.schema, claimSchema); // 3 constraints
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found here
   │
   = call trace:
     ->LinkedMultiQuery

Fixed